### PR TITLE
Added SendRawPostRequest method for sending raw data to server

### DIFF
--- a/plugin/src/GNativeHttpRequest.cs
+++ b/plugin/src/GNativeHttpRequest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Text;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -49,6 +50,14 @@ namespace Genome2DNativePlugin
             }
             
             _wrapper.StartCoroutine(SendRequest(UnityWebRequest.Post(GetUrlWithQueryParams(p_url, p_queryParams), form), p_headers));
+        }
+        
+        public void SendRawPostRequest(string p_url, string[][] p_headers, string[][] p_queryParams, string p_data)
+        {
+            UnityWebRequest request = new UnityWebRequest(GetUrlWithQueryParams(p_url, p_queryParams), "POST");
+            request.uploadHandler = (UploadHandler) new UploadHandlerRaw(Encoding.UTF8.GetBytes(p_data));
+            request.downloadHandler = (DownloadHandler) new DownloadHandlerBuffer();
+            _wrapper.StartCoroutine(SendRequest(request, p_headers));
         }
         
         public string ResponseText


### PR DESCRIPTION
You can use SendRawPostRequest to send JSON string like this:

```
var jsonString = "{ \"name\":\"John\", \"age\":30, \"car\":null }";
var headers = [["Content-Type", "application/json"]];
gNativeHttpRequest.SendRawPostRequest("http://server.com", headers, [], jsonString);
```

> SendPostRequest supports only form data to be send