### PR TITLE
Added explicit FileAccess to GNativeFileReader and GNativeFileWriter

### DIFF
--- a/plugin/src/GNativeFileReader.cs
+++ b/plugin/src/GNativeFileReader.cs
@@ -61,7 +61,7 @@ namespace Genome2DNativePlugin
         {
             try
             {
-                _fileStream = File.Open(p_filePath, FileMode.Open);
+                _fileStream = File.Open(p_filePath, FileMode.Open, FileAccess.Read);
                 
                 var bytesCount = (int)_fileStream.Length;
                 _result = new byte[bytesCount];

--- a/plugin/src/GNativeFileWriter.cs
+++ b/plugin/src/GNativeFileWriter.cs
@@ -16,12 +16,12 @@ namespace Genome2DNativePlugin
 
         public static void WriteSync(string p_filePath, byte[] p_bytes, int p_count)
         {
-            using (var fileStream = File.Open(p_filePath, FileMode.Create))
+            using (var fileStream = File.Open(p_filePath, FileMode.Create, FileAccess.Write))
             {
                 fileStream.Write(p_bytes, 0, p_count);
             }
         }
-        
+
         public static GNativeFileWriter WriteAsync(string p_filePath, byte[] p_bytes, int p_count, Action<GNativeFileWriter> p_onFlush, Action<GNativeFileWriter> p_onError)
         {
             return new GNativeFileWriter(p_filePath, p_bytes, p_count, p_onFlush, p_onError);
@@ -39,25 +39,25 @@ namespace Genome2DNativePlugin
         {
             get { return _error; }
         }
-        
+
         public void Close()
         {
             _onFlush = null;
             _onError = null;
             _error = null;
-            
+
             if (_fileStream != null)
             {
                 _fileStream.Dispose();
                 _fileStream = null;
             }
         }
-        
+
         private async void WriteToFile(string p_filePath, byte[] p_bytes, int p_count)
         {
             try
             {
-                _fileStream = File.Open(p_filePath, FileMode.Create);
+                _fileStream = File.Open(p_filePath, FileMode.Create, FileAccess.Write);
                 await _fileStream.WriteAsync(p_bytes, 0, p_count);
                 await _fileStream.FlushAsync();
                 


### PR DESCRIPTION
 This should fix denied access for reading from StreamingAssets on some ios devices