### PR TITLE
Allow multiple asynchronous reads from the same file

### DIFF
--- a/plugin/src/GNativeFileReader.cs
+++ b/plugin/src/GNativeFileReader.cs
@@ -61,7 +61,7 @@ namespace Genome2DNativePlugin
         {
             try
             {
-                _fileStream = File.Open(p_filePath, FileMode.Open, FileAccess.Read);
+                _fileStream = File.Open(p_filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
                 
                 var bytesCount = (int)_fileStream.Length;
                 _result = new byte[bytesCount];


### PR DESCRIPTION
Reading multiple files asynchronously from StreamingAssets caused access denied for subsequent reads